### PR TITLE
Updated OwlCore.Storage to 0.13.0, implemented ICreateRenamedCopyOf, IMoveRenamedFrom in FtpFolder.

### DIFF
--- a/src/FtpFolder.Interoperability.cs
+++ b/src/FtpFolder.Interoperability.cs
@@ -11,7 +11,21 @@ public partial class FtpFolder
         IFile fileToCopy,
         IModifiableFolder targetFolder,
         bool overwrite,
-        CreateCopyOfDelegate fallback,
+        CreateRenamedCopyOfDelegate fallback,
+        CancellationToken cancellationToken
+    )
+    {
+        return await CreateCopyOfInteroperableAsync(sourceClient, targetClient, fileToCopy, targetFolder, overwrite, fileToCopy.Name, fallback, cancellationToken);
+    }
+
+    private async Task<IChildFile> CreateCopyOfInteroperableAsync(
+        AsyncFtpClient sourceClient,
+        AsyncFtpClient targetClient,
+        IFile fileToCopy,
+        IModifiableFolder targetFolder,
+        bool overwrite,
+        string newName,
+        CreateRenamedCopyOfDelegate fallback,
         CancellationToken cancellationToken
     )
     {
@@ -20,7 +34,7 @@ public partial class FtpFolder
             targetClient.EnsureConnectedAsync(cancellationToken)
         );
 
-        var targetFilePath = global::System.IO.Path.Combine(Id, fileToCopy.Name);
+        var targetFilePath = global::System.IO.Path.Combine(Id, newName);
 
         var status = await sourceClient.TransferFile(
             fileToCopy.Id,
@@ -35,7 +49,7 @@ public partial class FtpFolder
             // Either the server does not support FXP or the transfer failed.
             // Only thing we can do in this case is to use the fallback
             // implementation.
-            return await fallback(this, fileToCopy, overwrite, cancellationToken);
+            return await fallback(this, fileToCopy, overwrite, newName, cancellationToken);
         }
 
         var file = await targetClient.GetStorableFromPathAsync(targetFilePath, cancellationToken);
@@ -53,7 +67,22 @@ public partial class FtpFolder
         IChildFile fileToMove,
         IModifiableFolder targetFolder,
         bool overwrite,
-        MoveFromDelegate fallback,
+        MoveRenamedFromDelegate fallback,
+        CancellationToken cancellationToken
+    )
+    {
+        return await MoveFromInteroperableAsync(sourceClient, targetClient, sourceFolder, fileToMove, targetFolder, overwrite, fileToMove.Name, fallback, cancellationToken);
+    }
+
+    private async Task<IChildFile> MoveFromInteroperableAsync(
+        AsyncFtpClient sourceClient,
+        AsyncFtpClient targetClient,
+        IModifiableFolder sourceFolder,
+        IChildFile fileToMove,
+        IModifiableFolder targetFolder,
+        bool overwrite,
+        string newName,
+        MoveRenamedFromDelegate fallback,
         CancellationToken cancellationToken
     )
     {
@@ -62,7 +91,7 @@ public partial class FtpFolder
             targetClient.EnsureConnectedAsync(cancellationToken)
         );
 
-        var targetFilePath = global::System.IO.Path.Combine(Id, fileToMove.Name);
+        var targetFilePath = global::System.IO.Path.Combine(Id, newName);
 
         var status = await sourceClient.TransferFile(
             fileToMove.Id,
@@ -77,7 +106,7 @@ public partial class FtpFolder
             // Either the server does not support FXP or the transfer failed.
             // Only thing we can do in this case is to use the fallback
             // implementation.
-            return await fallback(this, fileToMove, sourceFolder, overwrite, cancellationToken);
+            return await fallback(this, fileToMove, sourceFolder, overwrite, newName, cancellationToken);
         }
 
         await sourceClient.DeleteFile(fileToMove.Id, cancellationToken);

--- a/src/FtpFolder.cs
+++ b/src/FtpFolder.cs
@@ -9,8 +9,8 @@ public partial class FtpFolder :
     IGetItem,
     IGetFirstByName,
     IGetItemRecursive,
-    IMoveFrom,
-    ICreateCopyOf
+    ICreateRenamedCopyOf,
+    IMoveRenamedFrom
 {
     internal readonly AsyncFtpClient _ftpClient;
 
@@ -33,12 +33,21 @@ public partial class FtpFolder :
 
     public string Path => FtpListItem.FullName;
 
-    public async Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, CancellationToken cancellationToken, CreateCopyOfDelegate fallback)
+    public Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, CancellationToken cancellationToken, CreateCopyOfDelegate fallback)
+    {
+        // For code deduplication in this implementation,
+        // route to the overload with rename support
+        // while using the given non-rename overload as fallback.
+        // This also discards the filled newName param in the fallback, which is originally passed into the newName param in the following method call:
+        return CreateCopyOfAsync(fileToCopy, overwrite, newName: fileToCopy.Name, cancellationToken, (modifiableFolder, file, overwrite, _, cancellationToken) => fallback(modifiableFolder, file, overwrite, cancellationToken));
+    }
+
+    public async Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, string newName, CancellationToken cancellationToken, CreateRenamedCopyOfDelegate fallback)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
 
         if (fileToCopy is not FtpFile)
-            return await fallback(this, fileToCopy, overwrite, cancellationToken);
+            return await fallback(this, fileToCopy, overwrite, newName, cancellationToken);
         else
         {
             var ftpFile = (FtpFile)fileToCopy;
@@ -48,12 +57,11 @@ public partial class FtpFolder :
 
             if (sourceHostUri != targetHostUri)
             {
-                var targetFilePath = global::System.IO.Path.Combine(Id, fileToCopy.Name);
-                return await CreateCopyOfInteroperableAsync(ftpFile._ftpClient, _ftpClient, fileToCopy, this, overwrite, fallback, cancellationToken);
+                return await CreateCopyOfInteroperableAsync(ftpFile._ftpClient, _ftpClient, fileToCopy, this, overwrite, newName, fallback, cancellationToken);
             }
         }
 
-        var newFilePath = global::System.IO.Path.Combine(Id, fileToCopy.Name);
+        var newFilePath = global::System.IO.Path.Combine(Id, newName);
 
         if (!overwrite && await _ftpClient.FileExists(newFilePath, cancellationToken))
             throw new FileAlreadyExistsException("Destination file already exists.");
@@ -74,12 +82,21 @@ public partial class FtpFolder :
         return (IChildFile)item;
     }
 
-    public async Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, CancellationToken cancellationToken, MoveFromDelegate fallback)
+    public Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, CancellationToken cancellationToken, MoveFromDelegate fallback)
+    {
+        // For code deduplication in this implementation,
+        // route to the overload with rename support
+        // while using the given non-rename overload as fallback.
+        // This also discards the filled newName param in the fallback, which is originally passed into the newName param in the following method call:
+        return MoveFromAsync(fileToMove, source, overwrite, newName: fileToMove.Name, cancellationToken, (modifiableFolder, file, source, overwrite, _, cancellationToken) => fallback(modifiableFolder, file, source, overwrite, cancellationToken));
+    }
+
+    public async Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, string newName, CancellationToken cancellationToken, MoveRenamedFromDelegate fallback)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
 
         if (source is not FtpFolder)
-            return await fallback(this, fileToMove, source, overwrite, cancellationToken);
+            return await fallback(this, fileToMove, source, overwrite, newName, cancellationToken);
         else
         {
             var ftpFile = (FtpFile)fileToMove;
@@ -89,12 +106,11 @@ public partial class FtpFolder :
 
             if (sourceHostUri != targetHostUri)
             {
-                var targetFilePath = global::System.IO.Path.Combine(Id, ftpFile.Name);
-                return await MoveFromInteroperableAsync(ftpFile._ftpClient, _ftpClient, source, fileToMove, this, overwrite, fallback, cancellationToken);
+                return await MoveFromInteroperableAsync(ftpFile._ftpClient, _ftpClient, source, fileToMove, this, overwrite, newName, fallback, cancellationToken);
             }
         }
 
-        var newFilePath = global::System.IO.Path.Combine(Id, fileToMove.Name);
+        var newFilePath = global::System.IO.Path.Combine(Id, newName);
 
         if (!overwrite && await _ftpClient.FileExists(newFilePath, cancellationToken))
             throw new FileAlreadyExistsException("Destination file already exists.");

--- a/src/OwlCore.Storage.FluentFTP.csproj
+++ b/src/OwlCore.Storage.FluentFTP.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentFTP" Version="50.0.1" />
     <PackageReference Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageReference Include="OwlCore.Storage" Version="0.11.2" />
+    <PackageReference Include="OwlCore.Storage" Version="0.13.0" />
   </ItemGroup>
 
 </Project>

--- a/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
@@ -5,8 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-	<RunSettingsFilePath>$(MSBuildProjectDirectory)\.runsettings</RunSettingsFilePath>
-	<IsPackable>false</IsPackable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +16,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="OwlCore.Storage" Version="0.11.2" />
     <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.2" />
     <PackageReference Include="Ulid" Version="1.3.3" />
   </ItemGroup>


### PR DESCRIPTION
This PR follows the [0.13.0 release](https://github.com/Arlodotexe/OwlCore.Storage/pull/93), which added new rename-capable overloads for ICreateCopy and IMoveFrom. These have been implemented in FtpFolder.