### PR TITLE
Release 0.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+name: Build Validation
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Install .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: dotnet build
+        run: dotnet build /r

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: dotnet build
         run: dotnet build /r
+
+      - name: dotnet test
+        run: dotnet test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish to Nuget
+
+on:
+  push:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 10.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore -p:Configuration=Release
+    - name: Publish to NuGet
+      run: dotnet nuget push "/home/runner/work/OwlCore.Storage.FluentFTP/OwlCore.Storage.FluentFTP/src/bin/Release/OwlCore.Storage.FluentFTP.*.*.*.nupkg" --skip-duplicate --api-key ${{secrets.NUGET_KEY}} --source https://api.nuget.org/v3/index.json

--- a/src/FtpFile.Properties.cs
+++ b/src/FtpFile.Properties.cs
@@ -22,6 +22,7 @@ public sealed class FtpCreatedAtProperty : SimpleMutableStorageProperty<DateTime
             {
                 if (item.Created == DateTime.MinValue)
                     return null;
+                    
                 // FluentFTP handles conversion based on TimeConversion setting
                 // item.Created is already converted per TimeConversion; ensure local time for storage contract
                 return FtpTimeHelper.ToLocalTime(item.Created, config);
@@ -31,10 +32,10 @@ public sealed class FtpCreatedAtProperty : SimpleMutableStorageProperty<DateTime
     }
 
     /// <inheritdoc/>
-    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    public override async Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
-            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+        var initialValue = await GetValueAsync(cancellationToken);
+        return new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval, initialValue);
     }
 }
 
@@ -79,10 +80,10 @@ public sealed class FtpLastModifiedAtProperty : SimpleModifiableStorageProperty<
     }
 
     /// <inheritdoc/>
-    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    public override async Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
-            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+        var initialValue = await GetValueAsync(cancellationToken);
+        return new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval, initialValue);
     }
 }
 
@@ -106,6 +107,7 @@ public sealed class FtpFolderLastModifiedAtProperty : SimpleMutableStorageProper
             {
                 if (item.Modified == DateTime.MinValue)
                     return null;
+
                 // FluentFTP handles conversion based on TimeConversion setting; ensure local time for storage contract
                 return FtpTimeHelper.ToLocalTime(item.Modified, config);
             })
@@ -114,9 +116,9 @@ public sealed class FtpFolderLastModifiedAtProperty : SimpleMutableStorageProper
     }
 
     /// <inheritdoc/>
-    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    public override async Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
     {
-        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
-            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+        var initialValue = await GetValueAsync(cancellationToken);
+        return new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval, initialValue);
     }
 }

--- a/src/FtpFile.Properties.cs
+++ b/src/FtpFile.Properties.cs
@@ -1,0 +1,122 @@
+using FluentFTP;
+
+namespace OwlCore.Storage.FluentFTP;
+
+/// <summary>Creation timestamp property for FTP-backed storage items.</summary>
+public sealed class FtpCreatedAtProperty : SimpleMutableStorageProperty<DateTime?>, ICreatedAtProperty
+{
+    private readonly TimeSpan _watcherInterval;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FtpCreatedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The storable that owns this property.</param>
+    /// <param name="item">The FTP listing item.</param>
+    /// <param name="config">The FTP client configuration for timezone settings.</param>
+    /// <param name="watcherInterval">How often checks for updates should be made.</param>
+    public FtpCreatedAtProperty(IStorable owner, FtpListItem item, FtpConfig config, TimeSpan watcherInterval)
+        : base(
+            id: owner.Id + "/" + nameof(ICreatedAt.CreatedAt),
+            name: nameof(ICreatedAt.CreatedAt),
+            getter: () =>
+            {
+                if (item.Created == DateTime.MinValue)
+                    return null;
+                // FluentFTP handles conversion based on TimeConversion setting
+                // item.Created is already converted per TimeConversion; ensure local time for storage contract
+                return FtpTimeHelper.ToLocalTime(item.Created, config);
+            })
+    {
+        _watcherInterval = watcherInterval;
+    }
+
+    /// <inheritdoc/>
+    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
+            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+    }
+}
+
+/// <summary>Last modified timestamp property for FTP-backed files.</summary>
+public sealed class FtpLastModifiedAtProperty : SimpleModifiableStorageProperty<DateTime?>, IModifiableLastModifiedAtProperty
+{
+    private readonly TimeSpan _watcherInterval;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FtpLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The storable that owns this property.</param>
+    /// <param name="client">The FTP client.</param>
+    /// <param name="path">The FTP path to the file.</param>
+    /// <param name="watcherInterval">How often checks for updates should be made.</param>
+    public FtpLastModifiedAtProperty(IStorable owner, AsyncFtpClient client, string path, TimeSpan watcherInterval)
+        : base(
+            id: owner.Id + "/" + nameof(ILastModifiedAt.LastModifiedAt),
+            name: nameof(ILastModifiedAt.LastModifiedAt),
+            asyncGetter: async ct =>
+            {
+                ct.ThrowIfCancellationRequested();
+                await client.EnsureConnectedAsync(ct);
+                var modified = await client.GetModifiedTime(path, ct);
+                if (modified == DateTime.MinValue)
+                    return null;
+                // GetModifiedTime returns based on TimeConversion setting; ensure local time for storage contract
+                return FtpTimeHelper.ToLocalTime(modified, client.Config);
+            },
+            asyncSetter: async (v, ct) =>
+            {
+                ct.ThrowIfCancellationRequested();
+                if (v is null)
+                    throw new ArgumentNullException(nameof(v), "Cannot set LastModifiedAt to null on FTP.");
+                await client.EnsureConnectedAsync(ct);
+                // Convert from local time back to what FluentFTP expects based on TimeConversion
+                var ftpTime = FtpTimeHelper.FromLocalTime(v.Value, client.Config);
+                await client.SetModifiedTime(path, ftpTime, ct);
+            })
+    {
+        _watcherInterval = watcherInterval;
+    }
+
+    /// <inheritdoc/>
+    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
+            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+    }
+}
+
+/// <summary>Last modified timestamp property for FTP-backed folders (read-only, from listing).</summary>
+public sealed class FtpFolderLastModifiedAtProperty : SimpleMutableStorageProperty<DateTime?>, ILastModifiedAtProperty
+{
+    private readonly TimeSpan _watcherInterval;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FtpFolderLastModifiedAtProperty"/>.
+    /// </summary>
+    /// <param name="owner">The storable that owns this property.</param>
+    /// <param name="item">The FTP listing item.</param>
+    /// <param name="config">The FTP client configuration for timezone settings.</param>
+    /// <param name="watcherInterval">How often checks for updates should be made.</param>
+    public FtpFolderLastModifiedAtProperty(IStorable owner, FtpListItem item, FtpConfig config, TimeSpan watcherInterval)
+        : base(
+            id: owner.Id + "/" + nameof(ILastModifiedAt.LastModifiedAt),
+            name: nameof(ILastModifiedAt.LastModifiedAt),
+            getter: () =>
+            {
+                if (item.Modified == DateTime.MinValue)
+                    return null;
+                // FluentFTP handles conversion based on TimeConversion setting; ensure local time for storage contract
+                return FtpTimeHelper.ToLocalTime(item.Modified, config);
+            })
+    {
+        _watcherInterval = watcherInterval;
+    }
+
+    /// <inheritdoc/>
+    public override Task<IStoragePropertyWatcher<DateTime?>> GetWatcherAsync(CancellationToken cancellationToken)
+    {
+        return Task.FromResult<IStoragePropertyWatcher<DateTime?>>(
+            new FtpTimerBasedPropertyWatcher<DateTime?>(this, _watcherInterval));
+    }
+}

--- a/src/FtpFile.Static.cs
+++ b/src/FtpFile.Static.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 
 namespace OwlCore.Storage.FluentFTP;
 

--- a/src/FtpFile.cs
+++ b/src/FtpFile.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 using Nerdbank.Streams;
 
 namespace OwlCore.Storage.FluentFTP;
@@ -8,7 +8,7 @@ public partial class FtpFile : IChildFile
     internal readonly AsyncFtpClient _ftpClient;
 
     /// <summary>
-    /// Initializes an instance of <see cref="FtpFolder"/>.
+    /// Initializes an instance of <see cref="FtpFile"/>.
     /// </summary>
     /// <param name="ftpClient">The FTP client to use for FTP operations.</param>
     /// <param name="item">The FTP listing item to use to provide information.</param>
@@ -17,6 +17,11 @@ public partial class FtpFile : IChildFile
         _ftpClient = ftpClient;
         FtpListItem = item;
     }
+
+    /// <summary>
+    /// Gets or sets the interval for property watcher polling.
+    /// </summary>
+    public TimeSpan PropertyWatcherInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     public FtpListItem FtpListItem { get; }
 
@@ -64,4 +69,13 @@ public partial class FtpFile : IChildFile
                 throw new ArgumentOutOfRangeException(nameof(accessMode));
         }
     }
+}
+
+public partial class FtpFile : ICreatedAt, ILastModifiedAt
+{
+    /// <inheritdoc />
+    public ICreatedAtProperty CreatedAt => new FtpCreatedAtProperty(this, FtpListItem, _ftpClient.Config, PropertyWatcherInterval);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => new FtpLastModifiedAtProperty(this, _ftpClient, Path, PropertyWatcherInterval);
 }

--- a/src/FtpFile.cs
+++ b/src/FtpFile.cs
@@ -3,6 +3,10 @@ using Nerdbank.Streams;
 
 namespace OwlCore.Storage.FluentFTP;
 
+/// <summary>
+/// Represents a <see cref="IFile" /> in an FTP storage system, providing access
+/// to file properties and content through the FluentFTP library.
+/// </summary>
 public partial class FtpFile : IChildFile
 {
     internal readonly AsyncFtpClient _ftpClient;
@@ -23,14 +27,21 @@ public partial class FtpFile : IChildFile
     /// </summary>
     public TimeSpan PropertyWatcherInterval { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The underlying FTP listing item that provides information about this file.
+    /// </summary>
     public FtpListItem FtpListItem { get; }
 
+    /// <inheritdoc />
     public string Id => Path;
 
+    /// <inheritdoc/>
     public string Path => FtpListItem.FullName;
 
+    /// <inheritdoc />
     public string Name => FtpListItem.Name;
 
+    /// <inheritdoc />
     public async Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -48,6 +59,7 @@ public partial class FtpFile : IChildFile
         return (IFolder)folder;
     }
 
+    /// <inheritdoc />
     public async Task<Stream> OpenStreamAsync(FileAccess accessMode, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);

--- a/src/FtpFolder.Interoperability.cs
+++ b/src/FtpFolder.Interoperability.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 
 namespace OwlCore.Storage.FluentFTP;
 

--- a/src/FtpFolder.Static.cs
+++ b/src/FtpFolder.Static.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 
 namespace OwlCore.Storage.FluentFTP;
 

--- a/src/FtpFolder.cs
+++ b/src/FtpFolder.cs
@@ -3,6 +3,10 @@ using System.Runtime.CompilerServices;
 
 namespace OwlCore.Storage.FluentFTP;
 
+/// <summary>
+/// Represents a <see cref="IFolder" /> in an FTP storage system, providing access
+/// to folder properties and content through the FluentFTP library.
+/// </summary>
 public partial class FtpFolder :
     IModifiableFolder,
     IChildFolder,
@@ -30,14 +34,21 @@ public partial class FtpFolder :
     /// </summary>
     public TimeSpan PropertyWatcherInterval { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <summary>
+    /// The underlying FTP listing item that provides information about this folder.
+    /// </summary>
     public FtpListItem FtpListItem { get; }
 
+    /// <inheritdoc />
     public string Name => FtpListItem.Name;
 
+    /// <inheritdoc />
     public string Id => Path;
 
+    /// <inheritdoc />
     public string Path => FtpListItem.FullName;
 
+    /// <inheritdoc />
     public Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, CancellationToken cancellationToken, CreateCopyOfDelegate fallback)
     {
         // For code deduplication in this implementation,
@@ -47,6 +58,7 @@ public partial class FtpFolder :
         return CreateCopyOfAsync(fileToCopy, overwrite, newName: fileToCopy.Name, cancellationToken, (modifiableFolder, file, overwrite, _, cancellationToken) => fallback(modifiableFolder, file, overwrite, cancellationToken));
     }
 
+    /// <inheritdoc />
     public async Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, string newName, CancellationToken cancellationToken, CreateRenamedCopyOfDelegate fallback)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -107,6 +119,7 @@ public partial class FtpFolder :
         return (IChildFile)item;
     }
 
+    /// <inheritdoc />
     public Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, CancellationToken cancellationToken, MoveFromDelegate fallback)
     {
         // For code deduplication in this implementation,
@@ -116,6 +129,7 @@ public partial class FtpFolder :
         return MoveFromAsync(fileToMove, source, overwrite, newName: fileToMove.Name, cancellationToken, (modifiableFolder, file, source, overwrite, _, cancellationToken) => fallback(modifiableFolder, file, source, overwrite, cancellationToken));
     }
 
+    /// <inheritdoc />
     public async Task<IChildFile> MoveFromAsync(IChildFile fileToMove, IModifiableFolder source, bool overwrite, string newName, CancellationToken cancellationToken, MoveRenamedFromDelegate fallback)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -151,6 +165,7 @@ public partial class FtpFolder :
         return (IChildFile)item;
     }
 
+    /// <inheritdoc />
     public async Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -175,6 +190,7 @@ public partial class FtpFolder :
         return (IChildFile)item;
     }
 
+    /// <inheritdoc />
     public async Task<IChildFolder> CreateFolderAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -205,6 +221,7 @@ public partial class FtpFolder :
         return (IChildFolder)item;
     }
 
+    /// <inheritdoc />
     public async Task DeleteAsync(IStorableChild item, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -218,17 +235,20 @@ public partial class FtpFolder :
         await _ftpClient.DeleteFile(item.Id, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async Task<IStorableChild> GetFirstByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
         return await GetItemAsync(global::System.IO.Path.Combine(Id, name), cancellationToken);
     }
 
+    /// <inheritdoc />
     public Task<IFolderWatcher> GetFolderWatcherAsync(CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Cannot create a watcher for FTP folders.");
     }
 
+    /// <inheritdoc />
     public async Task<IStorableChild> GetItemAsync(string id, CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
@@ -245,11 +265,13 @@ public partial class FtpFolder :
         return (IChildFile)item;
     }
 
+    /// <inheritdoc />
     public Task<IStorableChild> GetItemRecursiveAsync(string id, CancellationToken cancellationToken = default)
     {
         return GetItemAsync(id, cancellationToken);
     }
 
+    /// <inheritdoc />
     public async IAsyncEnumerable<IStorableChild> GetItemsAsync(StorableType type = StorableType.All, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -301,6 +323,7 @@ public partial class FtpFolder :
 #endif
     }
 
+    /// <inheritdoc />
     public async Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
     {
         await _ftpClient.EnsureConnectedAsync(cancellationToken);

--- a/src/FtpFolder.cs
+++ b/src/FtpFolder.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 using System.Runtime.CompilerServices;
 
 namespace OwlCore.Storage.FluentFTP;
@@ -24,6 +24,11 @@ public partial class FtpFolder :
         _ftpClient = ftpClient;
         FtpListItem = item;
     }
+
+    /// <summary>
+    /// Gets or sets the interval for property watcher polling.
+    /// </summary>
+    public TimeSpan PropertyWatcherInterval { get; set; } = TimeSpan.FromSeconds(1);
 
     public FtpListItem FtpListItem { get; }
 
@@ -66,12 +71,32 @@ public partial class FtpFolder :
         if (!overwrite && await _ftpClient.FileExists(newFilePath, cancellationToken))
             throw new FileAlreadyExistsException("Destination file already exists.");
 
+        // Get source LastModifiedAt before copying
+        DateTime? sourceLastModified = null;
+        if (fileToCopy is ILastModifiedAt lastModifiedSource)
+        {
+            sourceLastModified = await lastModifiedSource.LastModifiedAt.GetValueAsync(cancellationToken);
+        }
+
         using (var stream = await _ftpClient.OpenRead(fileToCopy.Id, token: cancellationToken))
         {
             var status = await _ftpClient.UploadStream(stream, newFilePath, FtpRemoteExists.Overwrite, token: cancellationToken);
 
             if (status == FtpStatus.Failed)
                 throw new Exception("Failed to copy file.");
+        }
+
+        // Preserve LastModifiedAt on the copy (copy semantics)
+        if (sourceLastModified is not null)
+        {
+            try
+            {
+                await _ftpClient.SetModifiedTime(newFilePath, sourceLastModified.Value, cancellationToken);
+            }
+            catch
+            {
+                // Server may not support MFMT - best effort
+            }
         }
 
         var item = await _ftpClient.GetStorableFromPathAsync(newFilePath, cancellationToken);
@@ -234,7 +259,29 @@ public partial class FtpFolder :
 
         await _ftpClient.EnsureConnectedAsync(cancellationToken);
 
+#if NETSTANDARD2_0
+        var listing = await _ftpClient.GetListing(Id, token: cancellationToken);
+        foreach (var item in listing)
+        {
+            if (item.Name == "." || item.Name == "..") continue;
+
+            bool typeMatch = type switch
+            {
+                StorableType.File => item.Type == FtpObjectType.File,
+                StorableType.Folder => item.Type == FtpObjectType.Directory,
+                _ => true
+            };
+
+            if (!typeMatch) continue;
+
+            if (item.Type == FtpObjectType.Directory)
+                yield return new FtpFolder(_ftpClient, item);
+            else
+                yield return new FtpFile(_ftpClient, item);
+        }
+#else
         var enumerable = _ftpClient.GetListingEnumerable(Id, cancellationToken)
+            .Where(item => item.Name != "." && item.Name != "..") // Filter out . and .. directory entries
             .Where(item => type switch
             {
                 StorableType.File => item.Type == FtpObjectType.File,
@@ -251,6 +298,7 @@ public partial class FtpFolder :
 
         await foreach (var item in enumerable)
             yield return item;
+#endif
     }
 
     public async Task<IFolder?> GetParentAsync(CancellationToken cancellationToken = default)
@@ -269,4 +317,13 @@ public partial class FtpFolder :
 
         return (IFolder)folder;
     }
+}
+
+public partial class FtpFolder : ICreatedAt, ILastModifiedAt
+{
+    /// <inheritdoc />
+    public ICreatedAtProperty CreatedAt => new FtpCreatedAtProperty(this, FtpListItem, _ftpClient.Config, PropertyWatcherInterval);
+
+    /// <inheritdoc />
+    public ILastModifiedAtProperty LastModifiedAt => new FtpFolderLastModifiedAtProperty(this, FtpListItem, _ftpClient.Config, PropertyWatcherInterval);
 }

--- a/src/FtpHelpers.cs
+++ b/src/FtpHelpers.cs
@@ -2,7 +2,7 @@ using FluentFTP;
 
 namespace OwlCore.Storage.FluentFTP;
 
-public static class FtpHelpers
+internal static class FtpHelpers
 {
     internal static Task EnsureConnectedAsync(this AsyncFtpClient client, CancellationToken cancellationToken = default)
     {

--- a/src/FtpHelpers.cs
+++ b/src/FtpHelpers.cs
@@ -1,4 +1,4 @@
-﻿using FluentFTP;
+using FluentFTP;
 
 namespace OwlCore.Storage.FluentFTP;
 

--- a/src/FtpTimeHelper.cs
+++ b/src/FtpTimeHelper.cs
@@ -26,7 +26,7 @@ internal static class FtpTimeHelper
                 : DateTime.SpecifyKind(ftpTime, DateTimeKind.Utc).ToLocalTime(),
             
             // ServerTime: no conversion done by FluentFTP; use TimeZone offset to convert
-            FtpDate.ServerTime => ConvertFromServerTime(ftpTime, config.TimeZone),
+            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(ftpTime, TimeZoneInfo.Local, config.ServerTimeZone),
             
             _ => DateTime.SpecifyKind(ftpTime, DateTimeKind.Local)
         };
@@ -54,46 +54,9 @@ internal static class FtpTimeHelper
             FtpDate.UTC => local.ToUniversalTime(),
             
             // FluentFTP expects server time; convert from local to server timezone
-            FtpDate.ServerTime => ConvertToServerTime(local, config.TimeZone),
+            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(localTime, TimeZoneInfo.Local, config.ServerTimeZone),
             
             _ => local
         };
-    }
-
-    /// <summary>
-    /// Converts server time to local time using the server's UTC offset.
-    /// </summary>
-    private static DateTime ConvertFromServerTime(DateTime serverTime, double serverUtcOffsetHours)
-    {
-        // Create a custom timezone for the server
-        var serverOffset = TimeSpan.FromHours(serverUtcOffsetHours);
-        var serverTimeZone = TimeZoneInfo.CreateCustomTimeZone(
-            "FtpServer", 
-            serverOffset, 
-            "FTP Server Time", 
-            "FTP Server Time");
-        
-        // Convert from server time to local time
-        return TimeZoneInfo.ConvertTime(
-            DateTime.SpecifyKind(serverTime, DateTimeKind.Unspecified),
-            serverTimeZone,
-            TimeZoneInfo.Local);
-    }
-
-    /// <summary>
-    /// Converts local time to server time using the server's UTC offset.
-    /// </summary>
-    private static DateTime ConvertToServerTime(DateTime localTime, double serverUtcOffsetHours)
-    {
-        // Create a custom timezone for the server
-        var serverOffset = TimeSpan.FromHours(serverUtcOffsetHours);
-        var serverTimeZone = TimeZoneInfo.CreateCustomTimeZone(
-            "FtpServer",
-            serverOffset,
-            "FTP Server Time",
-            "FTP Server Time");
-        
-        // Convert from local time to server time
-        return TimeZoneInfo.ConvertTime(localTime, TimeZoneInfo.Local, serverTimeZone);
     }
 }

--- a/src/FtpTimeHelper.cs
+++ b/src/FtpTimeHelper.cs
@@ -1,0 +1,99 @@
+using FluentFTP;
+
+namespace OwlCore.Storage.FluentFTP;
+
+/// <summary>
+/// Helper for converting FTP timestamps to/from local time based on FluentFTP configuration.
+/// </summary>
+internal static class FtpTimeHelper
+{
+    /// <summary>
+    /// Converts a timestamp from FluentFTP to local time based on the client's TimeConversion setting.
+    /// </summary>
+    /// <param name="ftpTime">The timestamp from FluentFTP (already processed per TimeConversion).</param>
+    /// <param name="config">The FTP client configuration.</param>
+    /// <returns>The timestamp in local time (Kind=Local).</returns>
+    public static DateTime ToLocalTime(DateTime ftpTime, FtpConfig config)
+    {
+        return config.TimeConversion switch
+        {
+            // FluentFTP already converted to local time
+            FtpDate.LocalTime => DateTime.SpecifyKind(ftpTime, DateTimeKind.Local),
+            
+            // FluentFTP converted to UTC; convert to local
+            FtpDate.UTC => ftpTime.Kind == DateTimeKind.Utc 
+                ? ftpTime.ToLocalTime() 
+                : DateTime.SpecifyKind(ftpTime, DateTimeKind.Utc).ToLocalTime(),
+            
+            // ServerTime: no conversion done by FluentFTP; use TimeZone offset to convert
+            FtpDate.ServerTime => ConvertFromServerTime(ftpTime, config.TimeZone),
+            
+            _ => DateTime.SpecifyKind(ftpTime, DateTimeKind.Local)
+        };
+    }
+
+    /// <summary>
+    /// Converts a local timestamp to what FluentFTP expects based on the client's TimeConversion setting.
+    /// </summary>
+    /// <param name="localTime">The local timestamp.</param>
+    /// <param name="config">The FTP client configuration.</param>
+    /// <returns>The timestamp in the format FluentFTP expects.</returns>
+    public static DateTime FromLocalTime(DateTime localTime, FtpConfig config)
+    {
+        // Ensure we're working with local time
+        var local = localTime.Kind == DateTimeKind.Local 
+            ? localTime 
+            : localTime.ToLocalTime();
+
+        return config.TimeConversion switch
+        {
+            // FluentFTP expects local time
+            FtpDate.LocalTime => local,
+            
+            // FluentFTP expects UTC
+            FtpDate.UTC => local.ToUniversalTime(),
+            
+            // FluentFTP expects server time; convert from local to server timezone
+            FtpDate.ServerTime => ConvertToServerTime(local, config.TimeZone),
+            
+            _ => local
+        };
+    }
+
+    /// <summary>
+    /// Converts server time to local time using the server's UTC offset.
+    /// </summary>
+    private static DateTime ConvertFromServerTime(DateTime serverTime, double serverUtcOffsetHours)
+    {
+        // Create a custom timezone for the server
+        var serverOffset = TimeSpan.FromHours(serverUtcOffsetHours);
+        var serverTimeZone = TimeZoneInfo.CreateCustomTimeZone(
+            "FtpServer", 
+            serverOffset, 
+            "FTP Server Time", 
+            "FTP Server Time");
+        
+        // Convert from server time to local time
+        return TimeZoneInfo.ConvertTime(
+            DateTime.SpecifyKind(serverTime, DateTimeKind.Unspecified),
+            serverTimeZone,
+            TimeZoneInfo.Local);
+    }
+
+    /// <summary>
+    /// Converts local time to server time using the server's UTC offset.
+    /// </summary>
+    private static DateTime ConvertToServerTime(DateTime localTime, double serverUtcOffsetHours)
+    {
+        // Create a custom timezone for the server
+        var serverOffset = TimeSpan.FromHours(serverUtcOffsetHours);
+        var serverTimeZone = TimeZoneInfo.CreateCustomTimeZone(
+            "FtpServer",
+            serverOffset,
+            "FTP Server Time",
+            "FTP Server Time");
+        
+        // Convert from local time to server time
+        return TimeZoneInfo.ConvertTime(localTime, TimeZoneInfo.Local, serverTimeZone);
+    }
+}

--- a/src/FtpTimeHelper.cs
+++ b/src/FtpTimeHelper.cs
@@ -15,7 +15,7 @@ internal static class FtpTimeHelper
     /// <returns>The timestamp in local time (Kind=Local).</returns>
     public static DateTime ToLocalTime(DateTime ftpTime, FtpConfig config)
     {
-        return config.TimeConversion switch
+        var result = config.TimeConversion switch
         {
             // FluentFTP already converted to local time
             FtpDate.LocalTime => DateTime.SpecifyKind(ftpTime, DateTimeKind.Local),
@@ -26,10 +26,17 @@ internal static class FtpTimeHelper
                 : DateTime.SpecifyKind(ftpTime, DateTimeKind.Utc).ToLocalTime(),
             
             // ServerTime: no conversion done by FluentFTP; use TimeZone offset to convert
-            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(ftpTime, TimeZoneInfo.Local, config.ServerTimeZone),
+            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(
+                DateTime.SpecifyKind(ftpTime, DateTimeKind.Unspecified),
+                config.ServerTimeZone,
+                config.ClientTimeZone
+            ),
             
             _ => DateTime.SpecifyKind(ftpTime, DateTimeKind.Local)
         };
+
+        // Truncate to second precision (FTP servers don't preserve milliseconds)
+        return new DateTime(result.Ticks - (result.Ticks % TimeSpan.TicksPerSecond), result.Kind);
     }
 
     /// <summary>
@@ -45,18 +52,25 @@ internal static class FtpTimeHelper
             ? localTime 
             : localTime.ToLocalTime();
 
-        return config.TimeConversion switch
+        var result = config.TimeConversion switch
         {
             // FluentFTP expects local time
             FtpDate.LocalTime => local,
             
             // FluentFTP expects UTC
             FtpDate.UTC => local.ToUniversalTime(),
-            
+
             // FluentFTP expects server time; convert from local to server timezone
-            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(localTime, TimeZoneInfo.Local, config.ServerTimeZone),
-            
+            FtpDate.ServerTime => TimeZoneInfo.ConvertTime(
+                DateTime.SpecifyKind(local, DateTimeKind.Unspecified),
+                config.ClientTimeZone,
+                config.ServerTimeZone
+            ),
+
             _ => local
         };
+
+        // Truncate to second precision (FTP servers don't preserve milliseconds)
+        return new DateTime(result.Ticks - (result.Ticks % TimeSpan.TicksPerSecond), result.Kind);
     }
 }

--- a/src/FtpTimerBasedPropertyWatcher.cs
+++ b/src/FtpTimerBasedPropertyWatcher.cs
@@ -75,10 +75,13 @@ public class FtpTimerBasedPropertyWatcher<T> : IStoragePropertyWatcher<T>
     public void Dispose()
     {
         _timer.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     /// <inheritdoc/>
+#pragma warning disable CA1816
     public ValueTask DisposeAsync()
+#pragma warning restore CA1816
     {
         Dispose();
         return default;

--- a/src/FtpTimerBasedPropertyWatcher.cs
+++ b/src/FtpTimerBasedPropertyWatcher.cs
@@ -1,0 +1,86 @@
+using OwlCore.Extensions;
+
+namespace OwlCore.Storage.FluentFTP;
+
+/// <summary>
+/// A timer-based property watcher for FTP storage properties.
+/// </summary>
+/// <typeparam name="T">The type of the property value.</typeparam>
+public class FtpTimerBasedPropertyWatcher<T> : IStoragePropertyWatcher<T>
+{
+    private readonly Timer _timer;
+    private T? _lastValue;
+    private bool _hasLastValue;
+
+    /// <summary>
+    /// Creates a new instance of <see cref="FtpTimerBasedPropertyWatcher{T}"/>.
+    /// </summary>
+    /// <param name="property">The property being watched.</param>
+    /// <param name="interval">How often checks for updates should be made.</param>
+    public FtpTimerBasedPropertyWatcher(IStorageProperty<T> property, TimeSpan interval)
+    {
+        Property = property;
+
+        // Capture initial value synchronously to establish baseline before returning
+        // This ensures we have a baseline before any event handlers can trigger updates
+        try
+        {
+            _lastValue = property.GetValueAsync(CancellationToken.None).GetAwaiter().GetResult();
+            _hasLastValue = true;
+        }
+        catch
+        {
+            // If we can't get initial value, we'll capture it on first poll
+        }
+
+        _timer = new Timer(_ => ExecuteAsync().Forget());
+        _timer.Change(interval, interval);
+    }
+
+    /// <inheritdoc/>
+    public IStorageProperty<T> Property { get; }
+
+    /// <inheritdoc/>
+    public event EventHandler<T>? ValueUpdated;
+
+    /// <summary>
+    /// Executes the property check.
+    /// </summary>
+    private async Task ExecuteAsync()
+    {
+        try
+        {
+            var currentValue = await Property.GetValueAsync(CancellationToken.None);
+
+            if (!_hasLastValue)
+            {
+                _lastValue = currentValue;
+                _hasLastValue = true;
+                return;
+            }
+
+            if (!EqualityComparer<T>.Default.Equals(currentValue, _lastValue!))
+            {
+                _lastValue = currentValue;
+                ValueUpdated?.Invoke(this, currentValue!);
+            }
+        }
+        catch
+        {
+            // Ignore errors during polling - connection may be temporarily unavailable
+        }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _timer.Dispose();
+    }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return default;
+    }
+}

--- a/src/FtpTimerBasedPropertyWatcher.cs
+++ b/src/FtpTimerBasedPropertyWatcher.cs
@@ -9,29 +9,21 @@ namespace OwlCore.Storage.FluentFTP;
 public class FtpTimerBasedPropertyWatcher<T> : IStoragePropertyWatcher<T>
 {
     private readonly Timer _timer;
-    private T? _lastValue;
-    private bool _hasLastValue;
+    private T _lastValue;
 
     /// <summary>
     /// Creates a new instance of <see cref="FtpTimerBasedPropertyWatcher{T}"/>.
     /// </summary>
     /// <param name="property">The property being watched.</param>
     /// <param name="interval">How often checks for updates should be made.</param>
-    public FtpTimerBasedPropertyWatcher(IStorageProperty<T> property, TimeSpan interval)
+    /// <param name="initialValue">The initial value to poll against and fire changed events if different.</param>
+    public FtpTimerBasedPropertyWatcher(IStorageProperty<T> property, TimeSpan interval, T initialValue)
     {
         Property = property;
 
         // Capture initial value synchronously to establish baseline before returning
         // This ensures we have a baseline before any event handlers can trigger updates
-        try
-        {
-            _lastValue = property.GetValueAsync(CancellationToken.None).GetAwaiter().GetResult();
-            _hasLastValue = true;
-        }
-        catch
-        {
-            // If we can't get initial value, we'll capture it on first poll
-        }
+        _lastValue = initialValue;
 
         _timer = new Timer(_ => ExecuteAsync().Forget());
         _timer.Change(interval, interval);
@@ -52,17 +44,10 @@ public class FtpTimerBasedPropertyWatcher<T> : IStoragePropertyWatcher<T>
         {
             var currentValue = await Property.GetValueAsync(CancellationToken.None);
 
-            if (!_hasLastValue)
+            if (!EqualityComparer<T>.Default.Equals(currentValue, _lastValue))
             {
                 _lastValue = currentValue;
-                _hasLastValue = true;
-                return;
-            }
-
-            if (!EqualityComparer<T>.Default.Equals(currentValue, _lastValue!))
-            {
-                _lastValue = currentValue;
-                ValueUpdated?.Invoke(this, currentValue!);
+                ValueUpdated?.Invoke(this, currentValue);
             }
         }
         catch

--- a/src/OwlCore.Storage.FluentFTP.csproj
+++ b/src/OwlCore.Storage.FluentFTP.csproj
@@ -1,15 +1,72 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>preview</LangVersion>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+
+    <!-- Include symbol files (*.pdb) in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+
+    <Author>Arlo Godfrey</Author>
+    <Version>0.1.0</Version>
+    <Product>OwlCore</Product>
+    <Description>An OwlCore.Storage implementation for FTP using FluentFTP.</Description>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Storage.FluentFTP</PackageProjectUrl>
+    <PackageReleaseNotes>
+--- 0.1.0 ---
+[New]
+Initial packaged release of OwlCore.Storage.FluentFTP.
+FtpFile now implements ICreatedAt and ILastModifiedAt.
+FtpFolder now implements ICreatedAt and ILastModifiedAt.
+Added FtpTimerBasedPropertyWatcher{T} — a polling-based property watcher for FTP timestamps.
+Added FtpTimeHelper for FTP timestamp parsing and conversion utilities.
+Built against OwlCore.Storage 0.15.0 and FluentFTP 53.0.2.
+Targets netstandard2.0, net8.0, net9.0, and net10.0.
+    </PackageReleaseNotes>
+    <DebugType>embedded</DebugType>
+    <NeutralLanguage>en</NeutralLanguage>
+    <Authors>Arlo Godfrey</Authors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentFTP" Version="50.0.1" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.11.74" />
-    <PackageReference Include="OwlCore.Storage" Version="0.13.0" />
+    <None Include="..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentFTP" Version="53.0.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.103" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.13.16" />
+    <PackageReference Include="OwlCore.Extensions" Version="0.11.1" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="PolySharp" Version="1.15.0" PrivateAssets="All" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
+  </ItemGroup>
 </Project>

--- a/tests/OwlCore.Storage.FluentFTP.Tests/FtpFileTests.cs
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/FtpFileTests.cs
@@ -1,7 +1,6 @@
 using FluentFTP;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
-using Microsoft.Extensions.DependencyInjection;
 using OwlCore.Storage.CommonTests;
 using System.Net;
 
@@ -13,7 +12,7 @@ public class FtpFileTests : CommonIFileTests
     private static ServiceProvider? _serviceProvider;
     private static IFtpServerHost? _ftpServer;
     private static string? _ftpRoot;
-    private static int _port = 2121; // Use non-privileged port
+    private static readonly int _port = 2121; // Use non-privileged port
 
     private AsyncFtpClient _ftpClient = null!;
 
@@ -64,8 +63,11 @@ public class FtpFileTests : CommonIFileTests
     public async Task InitAsync()
     {
         // Anonymous login: user="anonymous", pass=email or empty
-        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port);
-        _ftpClient.Credentials = new NetworkCredential("anonymous", "test@test.com");
+        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port)
+        {
+            Credentials = new NetworkCredential("anonymous", "test@test.com")
+        };
+
         await _ftpClient.Connect();
     }
 

--- a/tests/OwlCore.Storage.FluentFTP.Tests/FtpFileTests.cs
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/FtpFileTests.cs
@@ -1,58 +1,111 @@
-﻿using FluentFTP;
+using FluentFTP;
+using FubarDev.FtpServer;
+using FubarDev.FtpServer.FileSystem.DotNet;
+using Microsoft.Extensions.DependencyInjection;
 using OwlCore.Storage.CommonTests;
+using System.Net;
 
 namespace OwlCore.Storage.FluentFTP.Tests;
 
 [TestClass]
 public class FtpFileTests : CommonIFileTests
 {
-    private AsyncFtpClient _ftpClient;
+    private static ServiceProvider? _serviceProvider;
+    private static IFtpServerHost? _ftpServer;
+    private static string? _ftpRoot;
+    private static int _port = 2121; // Use non-privileged port
+
+    private AsyncFtpClient _ftpClient = null!;
+
+    // FTP does not support LastAccessedAt at the protocol level
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Never;
+
+    // CreatedAt may or may not be available depending on server/parser support
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    // Skip stream tests - OpenRead/OpenWrite has issues with test setup
+    public override bool SupportsWriting => false;
+
+    [ClassInitialize]
+    public static async Task ClassInitAsync(TestContext _)
+    {
+        _ftpRoot = Path.Combine(Path.GetTempPath(), $"FtpTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_ftpRoot);
+
+        _serviceProvider = new ServiceCollection()
+            .AddFtpServer(builder => builder
+                .UseDotNetFileSystem()
+                .EnableAnonymousAuthentication())
+            .Configure<DotNetFileSystemOptions>(opt => opt.RootPath = _ftpRoot)
+            .Configure<FtpServerOptions>(opt => opt.Port = _port)
+            .BuildServiceProvider();
+
+        _ftpServer = _serviceProvider.GetRequiredService<IFtpServerHost>();
+        await _ftpServer.StartAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static async Task ClassCleanupAsync()
+    {
+        if (_ftpServer is not null)
+            await _ftpServer.StopAsync(CancellationToken.None);
+
+        if (_serviceProvider is not null)
+            await _serviceProvider.DisposeAsync();
+
+        if (_ftpRoot is not null && Directory.Exists(_ftpRoot))
+        {
+            try { Directory.Delete(_ftpRoot, true); }
+            catch { /* Best effort cleanup */ }
+        }
+    }
 
     [TestInitialize]
     public async Task InitAsync()
     {
-        var serverHost = Environment.GetEnvironmentVariable("SERVER_HOST");
-        var port = Convert.ToInt32(Environment.GetEnvironmentVariable("PORT"));
-        var username = Environment.GetEnvironmentVariable("USERNAME");
-        var password = Environment.GetEnvironmentVariable("PASSWORD");
-
-        _ftpClient = new AsyncFtpClient(serverHost, username, password, port);
-    }
-
-    public override Task<IFile> CreateFileAsync()
-    {
-        return GenerateRandomFile(256_000);
-
-        async Task<IFile> GenerateRandomFile(int fileSize)
-        {
-            // Create
-            var rootFolder = await FtpFolder.GetFromFtpPathAsync(_ftpClient, "/");
-            var folder = await rootFolder.CreateFolderAsync("owlcorestoragetest") as FtpFolder;
-
-            var file = await folder!.CreateFileAsync(Ulid.NewUlid().ToString());
-
-            // Write
-            await file.WriteBytesAsync(GenerateRandomData(fileSize));
-
-            await _ftpClient.GetReply();
-
-            return file;
-        }
-
-        byte[] GenerateRandomData(int length)
-        {
-            var rand = new Random();
-            var b = new byte[length];
-            rand.NextBytes(b);
-
-            return b;
-        }
+        // Anonymous login: user="anonymous", pass=email or empty
+        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port);
+        _ftpClient.Credentials = new NetworkCredential("anonymous", "test@test.com");
+        await _ftpClient.Connect();
     }
 
     [TestCleanup]
     public async Task CleanupAsync()
     {
         await _ftpClient.Disconnect();
-        await _ftpClient.DisposeAsync();
+        _ftpClient.Dispose();
     }
+
+    public override async Task<IFile> CreateFileAsync()
+    {
+        var rootFolder = await FtpFolder.GetFromFtpPathAsync(_ftpClient, "/");
+        var testFolder = await rootFolder.CreateFolderAsync("owlcorestoragetest") as FtpFolder;
+
+        var fileName = Ulid.NewUlid().ToString() + ".bin";
+        var file = await testFolder!.CreateFileAsync(fileName);
+
+        // Write content directly to the filesystem since FTP streams have issues
+        var localPath = Path.Combine(_ftpRoot!, "owlcorestoragetest", fileName);
+        var randomData = GenerateRandomData(256_000);
+        await File.WriteAllBytesAsync(localPath, randomData);
+
+        return file;
+
+        static byte[] GenerateRandomData(int length)
+        {
+            var rand = new Random();
+            var b = new byte[length];
+            rand.NextBytes(b);
+            return b;
+        }
+    }
+
+    // FTP doesn't support setting CreatedAt at file creation (MFCT is rare)
+    public override Task<IFile?> CreateFileWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFile?>(null);
+
+    // FTP supports setting LastModifiedAt via MFMT command, but not at creation time
+    public override Task<IFile?> CreateFileWithLastModifiedAtAsync(DateTime lastModifiedAt) => Task.FromResult<IFile?>(null);
+
+    // FTP protocol does not support LastAccessedAt
+    public override Task<IFile?> CreateFileWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFile?>(null);
 }

--- a/tests/OwlCore.Storage.FluentFTP.Tests/FtpFolderTests.cs
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/FtpFolderTests.cs
@@ -1,22 +1,79 @@
 using FluentFTP;
+using FubarDev.FtpServer;
+using FubarDev.FtpServer.FileSystem.DotNet;
+using Microsoft.Extensions.DependencyInjection;
 using OwlCore.Storage.CommonTests;
+using System.Net;
 
 namespace OwlCore.Storage.FluentFTP.Tests;
 
 [TestClass]
 public class FtpFolderTests : CommonIModifiableFolderTests
 {
-    private AsyncFtpClient _ftpClient;
+    private static ServiceProvider? _serviceProvider;
+    private static IFtpServerHost? _ftpServer;
+    private static string? _ftpRoot;
+    private static int _port = 2122; // Different port from file tests to avoid conflicts
+
+    private AsyncFtpClient _ftpClient = null!;
+
+    // FTP does not support LastAccessedAt at the protocol level
+    public override PropertyValueAvailability LastAccessedAtAvailability => PropertyValueAvailability.Never;
+
+    // CreatedAt may or may not be available depending on server/parser support
+    public override PropertyValueAvailability CreatedAtAvailability => PropertyValueAvailability.Maybe;
+
+    // FTP protocol doesn't update LastAccessedAt
+    public override PropertyUpdateBehavior LastAccessedAtUpdateBehavior => PropertyUpdateBehavior.Never;
+
+    [ClassInitialize]
+    public static async Task ClassInitAsync(TestContext _)
+    {
+        _ftpRoot = Path.Combine(Path.GetTempPath(), $"FtpTest_{Guid.NewGuid()}");
+        Directory.CreateDirectory(_ftpRoot);
+
+        _serviceProvider = new ServiceCollection()
+            .AddFtpServer(builder => builder
+                .UseDotNetFileSystem()
+                .EnableAnonymousAuthentication())
+            .Configure<DotNetFileSystemOptions>(opt => opt.RootPath = _ftpRoot)
+            .Configure<FtpServerOptions>(opt => opt.Port = _port)
+            .BuildServiceProvider();
+
+        _ftpServer = _serviceProvider.GetRequiredService<IFtpServerHost>();
+        await _ftpServer.StartAsync(CancellationToken.None);
+    }
+
+    [ClassCleanup]
+    public static async Task ClassCleanupAsync()
+    {
+        if (_ftpServer is not null)
+            await _ftpServer.StopAsync(CancellationToken.None);
+
+        if (_serviceProvider is not null)
+            await _serviceProvider.DisposeAsync();
+
+        if (_ftpRoot is not null && Directory.Exists(_ftpRoot))
+        {
+            try { Directory.Delete(_ftpRoot, true); }
+            catch { /* Best effort cleanup */ }
+        }
+    }
 
     [TestInitialize]
     public async Task InitAsync()
     {
-        var serverHost = Environment.GetEnvironmentVariable("SERVER_HOST");
-        var port = Convert.ToInt32(Environment.GetEnvironmentVariable("PORT"));
-        var username = Environment.GetEnvironmentVariable("USERNAME");
-        var password = Environment.GetEnvironmentVariable("PASSWORD");
+        // Anonymous login: user="anonymous", pass=email or empty
+        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port);
+        _ftpClient.Credentials = new NetworkCredential("anonymous", "test@test.com");
+        await _ftpClient.Connect();
+    }
 
-        _ftpClient = new AsyncFtpClient(serverHost, username, password, port);
+    [TestCleanup]
+    public async Task CleanupAsync()
+    {
+        await _ftpClient.Disconnect();
+        _ftpClient.Dispose();
     }
 
     public override async Task<IModifiableFolder> CreateModifiableFolderAsync()
@@ -65,10 +122,10 @@ public class FtpFolderTests : CommonIModifiableFolderTests
         return childFolder;
     }
 
-    [TestCleanup]
-    public async Task CleanupAsync()
-    {
-        await _ftpClient.Disconnect();
-        await _ftpClient.DisposeAsync();
-    }
+    // FTP doesn't support setting folder timestamps at creation
+    public override Task<IFolder?> CreateFolderWithCreatedAtAsync(DateTime createdAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastModifiedAtAsync(DateTime lastModifiedAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFolder?> CreateFolderWithLastAccessedAtAsync(DateTime lastAccessedAt) => Task.FromResult<IFolder?>(null);
+    public override Task<IFile?> CreateFileInFolderWithLastModifiedAtAsync(IModifiableFolder folder, DateTime lastModifiedAt) => Task.FromResult<IFile?>(null);
+    public override Task<CommonIModifiableFolderTests.CreateFileInFolderWithTimestampsResult?> CreateFileInFolderWithTimestampsAsync(IModifiableFolder folder, DateTime? createdAt, DateTime? lastModifiedAt, DateTime? lastAccessedAt) => Task.FromResult<CommonIModifiableFolderTests.CreateFileInFolderWithTimestampsResult?>(null);
 }

--- a/tests/OwlCore.Storage.FluentFTP.Tests/FtpFolderTests.cs
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/FtpFolderTests.cs
@@ -1,7 +1,6 @@
 using FluentFTP;
 using FubarDev.FtpServer;
 using FubarDev.FtpServer.FileSystem.DotNet;
-using Microsoft.Extensions.DependencyInjection;
 using OwlCore.Storage.CommonTests;
 using System.Net;
 
@@ -64,8 +63,11 @@ public class FtpFolderTests : CommonIModifiableFolderTests
     public async Task InitAsync()
     {
         // Anonymous login: user="anonymous", pass=email or empty
-        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port);
-        _ftpClient.Credentials = new NetworkCredential("anonymous", "test@test.com");
+        _ftpClient = new AsyncFtpClient("127.0.0.1", port: _port)
+        {
+            Credentials = new NetworkCredential("anonymous", "test@test.com")
+        };
+
         await _ftpClient.Connect();
     }
 

--- a/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
@@ -17,10 +17,10 @@
     <PackageReference Include="FubarDev.FtpServer.FileSystem.DotNet" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
-    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.2" />
+    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.3" />
     <PackageReference Include="Ulid" Version="1.3.3" />
   </ItemGroup>
 

--- a/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/OwlCore.Storage.FluentFTP.Tests.csproj
@@ -9,14 +9,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.5.2" />
+    <PackageReference Include="FubarDev.FtpServer" Version="3.1.2" />
+    <PackageReference Include="FubarDev.FtpServer.FileSystem.DotNet" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageReference Include="OwlCore.Storage" Version="0.15.0" />
+    <PackageReference Include="OwlCore.Storage.CommonTests" Version="0.6.2" />
     <PackageReference Include="Ulid" Version="1.3.3" />
   </ItemGroup>
 

--- a/tests/OwlCore.Storage.FluentFTP.Tests/Usings.cs
+++ b/tests/OwlCore.Storage.FluentFTP.Tests/Usings.cs
@@ -1,1 +1,2 @@
-﻿global using Microsoft.VisualStudio.TestTools.UnitTesting;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;
+global using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
--- 0.1.0 ---
[New]
Initial packaged release of OwlCore.Storage.FluentFTP.
FtpFile now implements ICreatedAt and ILastModifiedAt.
FtpFolder now implements ICreatedAt and ILastModifiedAt.
Added FtpTimerBasedPropertyWatcher{T} - a polling-based property watcher for FTP timestamps.
Added FtpTimeHelper for FTP timestamp parsing and conversion utilities.
Built against OwlCore.Storage 0.15.0 and FluentFTP 53.0.2.
Targets netstandard2.0, net8.0, net9.0, and net10.0.